### PR TITLE
[#49] fix: interview setting 페이지 css 수정 

### DIFF
--- a/client/src/pages/Interview/_components/setting/DiffSetup.jsx
+++ b/client/src/pages/Interview/_components/setting/DiffSetup.jsx
@@ -54,7 +54,10 @@ const DiffSetup = () => {
   const [selected, setSelected] = useState("신입");
 
   return (
-    <div className="mx-auto flex w-full flex-col items-center px-4 py-4 2xl:py-8">
+    <div
+      className="w- mx-auto flex w-full flex-col items-center justify-center px-4 py-4 2xl:py-8"
+      style={{ height: "calc(100vh - 14rem)" }}
+    >
       <div className="text-zik-text mt-4 mb-8 text-2xl font-bold">
         질문 난이도를 설정하세요
       </div>
@@ -68,7 +71,7 @@ const DiffSetup = () => {
               key={level.label}
               onClick={() => setSelected(level.label)}
               className={clsx(
-                "border-zik-border flex h-20 cursor-pointer flex-col justify-center rounded-xl border px-6 py-4 transition-all",
+                "border-zik-border flex h-20 cursor-pointer flex-col justify-center overflow-hidden rounded-xl border px-6 py-4 transition-all duration-300 ease-in-out",
                 {
                   "bg-zik-main/30 h-30 text-[#291B9A] duration-300 2xl:h-36":
                     isSelected,
@@ -106,11 +109,20 @@ const DiffSetup = () => {
                 </div>
               </div>
 
-              {isSelected && level.description && (
-                <p className="mt-2 px-14 text-sm leading-relaxed whitespace-pre-wrap text-[#291B9A] 2xl:text-base">
-                  {level.description}
-                </p>
-              )}
+              <div
+                className={clsx(
+                  "transform transition-all duration-300 ease-in-out",
+                  isSelected
+                    ? "max-h-40 translate-y-0 opacity-100"
+                    : "max-h-0 translate-y-[-10px] opacity-0",
+                )}
+              >
+                {level.description && (
+                  <p className="mt-2 px-14 text-sm leading-relaxed whitespace-pre-wrap text-[#291B9A] 2xl:text-base">
+                    {level.description}
+                  </p>
+                )}
+              </div>
             </li>
           );
         })}

--- a/client/src/pages/Interview/_components/setting/DragProgressBar.jsx
+++ b/client/src/pages/Interview/_components/setting/DragProgressBar.jsx
@@ -91,7 +91,7 @@ const DragProgressBar = () => {
 
           {/* 드래그 핸들 - 원형 */}
           <div
-            className="absolute top-1/2 z-10 -translate-y-1/2"
+            className="absolute top-1/2 z-10 -translate-y-1/2 transition-all duration-200 ease-in-out"
             style={{ left: `${rightValue}%` }}
             onMouseDown={handleDragStart}
             onTouchStart={handleDragStart}
@@ -101,7 +101,7 @@ const DragProgressBar = () => {
 
           {/* 컬러 인디케이터 */}
           <div
-            className="bg-zik-main absolute inset-y-0 left-0 rounded-l-full"
+            className="bg-zik-main absolute inset-y-0 left-0 rounded-l-full transition-all duration-200 ease-in-out"
             style={{ width: `${rightValue}%` }}
           ></div>
         </div>

--- a/client/src/pages/Interview/_components/setting/PreCheckStep.jsx
+++ b/client/src/pages/Interview/_components/setting/PreCheckStep.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { useLocation, useBeforeUnload } from "react-router-dom";
 import Button from "@/components/common/Button";
 import pencil from "@/assets/images/pencil.svg";
 // import task from "@/assets/images/task.svg";
@@ -15,7 +14,7 @@ const listWrap =
   "flex flex-1 min-w-0 flex-row justify-start gap-4 md:flex-col items-center md:justify-start";
 const imageWrap =
   "w-[clamp(60px,15vw,150px)] h-[clamp(60px,15vw,150px)] bg-[#ECEBFF] rounded-[50%] flex items-center justify-center border-[4px] border-zik-main/50";
-const imageSize = "w-[clamp(30px,8vw,100px)] h-[clamp(30px,8vw,100px)]";
+const imageSize = "w-[clamp(30px,8vw,80px)] h-[clamp(30px,8vw,80px)]";
 const textWrap =
   "md:mt-7 flex flex-col items-center justify-center flex items-start md:items-center whitespace-nowrap text-lg text-zik-text";
 
@@ -44,10 +43,13 @@ const PreCheckStep = () => {
   };
 
   const increase = () => {
-    if (count < 20) setCount(count + 1);
+    if (count < 10) setCount(count + 1);
   };
   return (
-    <div className="mx-auto flex w-full flex-col items-center px-4 py-8">
+    <div
+      className="mx-auto flex w-full flex-col items-center justify-center px-4 py-8"
+      style={{ height: "calc(100vh - 18rem)" }}
+    >
       <div className="text-zik-text mt-9 mb-8 text-2xl font-bold 2xl:mt-18">
         사전 체크
       </div>

--- a/client/src/pages/Interview/_components/setting/RoleSetup.jsx
+++ b/client/src/pages/Interview/_components/setting/RoleSetup.jsx
@@ -28,7 +28,10 @@ const RoleSetup = () => {
   };
 
   return (
-    <div className="mx-auto flex w-full flex-col items-center px-4 py-8">
+    <div
+      className="mx-auto flex w-full flex-col items-center justify-center px-4 py-8"
+      style={{ height: "calc(100vh - 18rem)" }}
+    >
       <div className="text-zik-text py-8 text-2xl font-bold 2xl:mb-2 2xl:py-16">
         질문 유형 비율을 설정하세요
       </div>


### PR DESCRIPTION
## Description

interview setting 페이지 css 수정 

## Changes Made

1. 질문 난이도 박스 애니메이션으로
2. 질문 유형 비율 bar 애니메이션
3. 사전체크 문항수 최대 10개로 제한
4. 사전체크 아이콘 사이즈 줄이기
5. 전체 레이아웃(장치 연결 제외) 가운데 정렬

## Screenshots

## IssueNumber

해당 이슈 넘버 ( #49 )
